### PR TITLE
fix: improve error handling in registration process

### DIFF
--- a/internal/custom_errors/errors.go
+++ b/internal/custom_errors/errors.go
@@ -4,14 +4,13 @@ import "errors"
 
 // Ошибки пользователя
 var (
-	ErrUserNotFound      = errors.New("user not found")
-	ErrUsernameExists    = errors.New("username already exists")
-	ErrEmailExists       = errors.New("email already exists")
-	ErrInvalidUsername   = errors.New("invalid username")
-	ErrInvalidEmail      = errors.New("invalid email")
-	ErrInvalidPassword   = errors.New("invalid password")
-	ErrPasswordMismatch  = errors.New("passwords do not match")
-	ErrUserAlreadyExists = errors.New("user already exists")
+	ErrUserNotFound     = errors.New("user not found")
+	ErrUsernameExists   = errors.New("username already exists")
+	ErrEmailExists      = errors.New("email already exists")
+	ErrInvalidUsername  = errors.New("invalid username")
+	ErrInvalidEmail     = errors.New("invalid email")
+	ErrInvalidPassword  = errors.New("invalid password")
+	ErrPasswordMismatch = errors.New("passwords do not match")
 )
 
 // Ошибки валидации

--- a/internal/delivery/grpc/auth/api_test.go
+++ b/internal/delivery/grpc/auth/api_test.go
@@ -109,11 +109,26 @@ func TestAuthGRPCService_Register(t *testing.T) {
 		assert.Equal(t, tokens.RefreshToken, resp.RefreshToken)
 	})
 
-	t.Run("user already exists", func(t *testing.T) {
+	t.Run("username already exists", func(t *testing.T) {
 		mockTokenService.ExpectedCalls = nil
 		mockTokenService.Calls = nil
 
-		mockTokenService.On("Register", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrUserAlreadyExists)
+		mockTokenService.On("Register", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrUsernameExists)
+
+		req := &pb.RegisterRequest{Username: "testuser", Email: "test@example.com", Password: "password123"}
+		resp, err := service.Register(context.Background(), req)
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("email already exists", func(t *testing.T) {
+		mockTokenService.ExpectedCalls = nil
+		mockTokenService.Calls = nil
+
+		mockTokenService.On("Register", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrEmailExists)
 
 		req := &pb.RegisterRequest{Username: "testuser", Email: "test@example.com", Password: "password123"}
 		resp, err := service.Register(context.Background(), req)

--- a/internal/delivery/grpc/auth/register.go
+++ b/internal/delivery/grpc/auth/register.go
@@ -17,7 +17,7 @@ type RegisterRequest struct {
 	Username  string `validate:"required,min=3"`
 	Email     string `validate:"required,email"`
 	Password  string `validate:"required,min=8"`
-	FullName  string `validate:"min=3,omitempty"`
+	FullName  string `validate:"omitempty,min=3"`
 	Bio       string `validate:"omitempty,min=8"`
 	AvatarUrl string `validate:"omitempty,min=8"`
 }
@@ -59,9 +59,6 @@ func (s *AuthGRPCService) Register(ctx context.Context, req *pb.RegisterRequest)
 		case errors.Is(err, custom_errors.ErrInvalidPassword):
 			s.log.Warn("Invalid password", "error", err, "username", req.Username)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
-		case errors.Is(err, custom_errors.ErrUserAlreadyExists):
-			s.log.Warn("User already exists", "username", req.Username, "email", req.Email)
-			return nil, status.Error(codes.AlreadyExists, err.Error())
 		case errors.Is(err, custom_errors.ErrUsernameExists):
 			s.log.Warn("Username already exists", "username", req.Username)
 			return nil, status.Error(codes.AlreadyExists, err.Error())

--- a/internal/service/token/service.go
+++ b/internal/service/token/service.go
@@ -138,6 +138,10 @@ func (s *Service) Register(ctx context.Context, user *model.User) (*auth.TokenPa
 			return nil, custom_errors.ErrInvalidPassword
 		case errors.Is(err, custom_errors.ErrExternalServiceError):
 			return nil, custom_errors.ErrExternalServiceError
+		case errors.Is(err, custom_errors.ErrUsernameExists):
+			return nil, custom_errors.ErrUsernameExists
+		case errors.Is(err, custom_errors.ErrEmailExists):
+			return nil, custom_errors.ErrEmailExists
 		default:
 			return nil, custom_errors.ErrInternalServiceError
 		}
@@ -269,7 +273,7 @@ func (s *Service) Logout(ctx context.Context, refreshToken string) error {
 	if err != nil {
 		s.log.Error("Failed to delete refresh token", slog.String("error", err.Error()), slog.String("jti", claims.JTI))
 		if errors.Is(err, custom_errors.ErrInvalidToken) {
-			return nil
+			return custom_errors.ErrInvalidToken
 		}
 		return custom_errors.ErrInternalServiceError
 	}

--- a/internal/service/token/service.go
+++ b/internal/service/token/service.go
@@ -128,8 +128,6 @@ func (s *Service) Register(ctx context.Context, user *model.User) (*auth.TokenPa
 	if err != nil {
 		s.log.Error("Failed to create user", slog.String("error", err.Error()), slog.String("username", user.Username))
 		switch {
-		case errors.Is(err, custom_errors.ErrUserAlreadyExists):
-			return nil, custom_errors.ErrUserAlreadyExists
 		case errors.Is(err, custom_errors.ErrInvalidUsername):
 			return nil, custom_errors.ErrInvalidUsername
 		case errors.Is(err, custom_errors.ErrInvalidEmail):

--- a/internal/service/token/service_test.go
+++ b/internal/service/token/service_test.go
@@ -204,13 +204,13 @@ func TestService_Register(t *testing.T) {
 		assert.Nil(t, gotTokens)
 	})
 
-	t.Run("user already exists", func(t *testing.T) {
+	t.Run("username already exists", func(t *testing.T) {
 		mockUserClient.ExpectedCalls = nil
 		mockUserClient.Calls = nil
 		mockTokenManager.ExpectedCalls = nil
 		mockTokenManager.Calls = nil
 
-		mockUserClient.On("CreateUser", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrUserAlreadyExists).Once()
+		mockUserClient.On("CreateUser", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrUsernameExists).Once()
 
 		gotTokens, err := service.Register(context.Background(), &model.User{
 			Username: "testuser",
@@ -218,7 +218,25 @@ func TestService_Register(t *testing.T) {
 			Password: "password123",
 		})
 		assert.Error(t, err)
-		assert.Equal(t, custom_errors.ErrUserAlreadyExists, err)
+		assert.Equal(t, custom_errors.ErrUsernameExists, err)
+		assert.Nil(t, gotTokens)
+	})
+
+	t.Run("email already exists", func(t *testing.T) {
+		mockUserClient.ExpectedCalls = nil
+		mockUserClient.Calls = nil
+		mockTokenManager.ExpectedCalls = nil
+		mockTokenManager.Calls = nil
+
+		mockUserClient.On("CreateUser", mock.Anything, mock.AnythingOfType("*model.User")).Return(nil, custom_errors.ErrEmailExists).Once()
+
+		gotTokens, err := service.Register(context.Background(), &model.User{
+			Username: "testuser",
+			Email:    "test@example.com",
+			Password: "password123",
+		})
+		assert.Error(t, err)
+		assert.Equal(t, custom_errors.ErrEmailExists, err)
 		assert.Nil(t, gotTokens)
 	})
 


### PR DESCRIPTION
This pull request enhances error handling in the authentication service by introducing more granular error checks and improving logging for better debugging and user feedback. It also fixes an issue in the logout process to ensure proper error propagation.

### Improvements to error handling:

* [`internal/delivery/grpc/auth/register.go`](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL40-L41): Replaced generic error checks with `errors.Is` to handle specific error types such as `ErrInvalidInput`, `ErrInvalidEmail`, `ErrInvalidPassword`, and others. Enhanced logging to include more detailed context, such as the username or email associated with the error. [[1]](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL40-L41) [[2]](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL51-R79)
* [`internal/service/token/service.go`](diffhunk://#diff-349a91e8090f35fb5668af0c12febfb465effceb79bcf86d577c0855b07893f1R141-R144): Added handling for new error types `ErrUsernameExists` and `ErrEmailExists` in the `Register` method to propagate these errors appropriately.

### Bug fix in logout process:

* [`internal/service/token/service.go`](diffhunk://#diff-349a91e8090f35fb5668af0c12febfb465effceb79bcf86d577c0855b07893f1L272-R276): Corrected the `Logout` method to return `ErrInvalidToken` instead of `nil` when an invalid token is encountered, ensuring proper error propagation.

### Miscellaneous:

* [`internal/delivery/grpc/auth/register.go`](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL40-L41): Removed redundant debug logging statements to reduce noise in the logs. [[1]](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL40-L41) [[2]](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecL51-R79)
* [`internal/delivery/grpc/auth/register.go`](diffhunk://#diff-f1c2ed4c49f0b5757f9b6c049dcf4c1d25d3f0dc794f31264a9cc1508130edecR5): Added the `errors` package import to support the use of `errors.Is`.