### PR TITLE
refactor: update Makefile and CI configuration for improved local tes…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
 
     - name: Start Full Infrastructure for Integration Tests
       working-directory: pinstack-system-tests
+      env:
+        AUTH_SERVICE_CONTEXT: ../
       run: |
         # Запускаем все необходимые контейнеры для интеграционных тестов
         docker compose -f docker-compose.test.yml up -d \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-integration test-user-integration clean build run docker-build setup-system-tests
+.PHONY: test test-unit test-integration test-user-integration clean build run docker-build setup-system-tests quick-test-local
 
 BINARY_NAME=auth-service
 DOCKER_IMAGE=pinstack-auth-service:latest
@@ -41,7 +41,7 @@ test-unit: check-go-version
 start-auth-infrastructure: setup-system-tests
 	@echo "🚀 Запуск полной инфраструктуры для интеграционных тестов..."
 	cd $(SYSTEM_TESTS_DIR) && \
-	docker compose -f docker-compose.test.yml up -d \
+	AUTH_SERVICE_CONTEXT=../pinstack-auth-service docker compose -f docker-compose.test.yml up -d \
 		user-db-test \
 		user-migrator-test \
 		user-service-test \
@@ -111,6 +111,20 @@ test-integration: test-auth-integration stop-auth-infrastructure
 # Все тесты
 test-all: fmt lint test-unit test-integration
 
+# Быстрый тест с локальным auth-service
+quick-test-local: setup-system-tests
+	@echo "⚡ Быстрый запуск тестов с локальным auth-service..."
+	cd $(SYSTEM_TESTS_DIR) && \
+	AUTH_SERVICE_CONTEXT=../pinstack-auth-service docker compose -f docker-compose.test.yml up -d \
+		user-db-test user-migrator-test user-service-test \
+		auth-db-test auth-migrator-test auth-service-test \
+		api-gateway-test
+	@echo "⏳ Ожидание готовности сервисов..."
+	@sleep 30
+	cd $(SYSTEM_TESTS_DIR) && \
+	go test -v -count=1 -timeout=5m ./internal/scenarios/integration/gateway_auth/...
+	$(MAKE) stop-auth-infrastructure
+
 # Логи сервисов
 logs-user:
 	cd $(SYSTEM_TESTS_DIR) && \
@@ -158,8 +172,15 @@ ci-local: test-all
 	@echo "🎉 Локальный CI завершен успешно!"
 
 # Быстрый тест (только запуск без пересборки)
-quick-test: start-auth-infrastructure
+quick-test: setup-system-tests
 	@echo "⚡ Быстрый запуск тестов без пересборки..."
+	cd $(SYSTEM_TESTS_DIR) && \
+	AUTH_SERVICE_CONTEXT=../pinstack-auth-service docker compose -f docker-compose.test.yml up -d \
+		user-db-test user-migrator-test user-service-test \
+		auth-db-test auth-migrator-test auth-service-test \
+		api-gateway-test
+	@echo "⏳ Ожидание готовности сервисов..."
+	@sleep 30
 	cd $(SYSTEM_TESTS_DIR) && \
 	go test -v -count=1 -timeout=5m ./internal/scenarios/integration/gateway_auth/...
 	$(MAKE) stop-auth-infrastructure

--- a/internal/application/service/service_test.go
+++ b/internal/application/service/service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "pinstack-auth-service/internal/application/service"
-	models "pinstack-auth-service/internal/domain/models"
+	"pinstack-auth-service/internal/domain/models"
 	ports "pinstack-auth-service/internal/domain/ports/input"
 	"pinstack-auth-service/internal/infrastructure/logger"
 	"pinstack-auth-service/internal/utils"


### PR DESCRIPTION
This pull request introduces improvements to the local and CI testing workflows, making it easier and faster to run integration tests with a local `auth-service`. It adds a new Makefile target for quick local testing, ensures environment variables are properly set for Docker Compose, and makes minor code style adjustments.

**Testing workflow enhancements:**

* Added a new `quick-test-local` Makefile target to quickly run integration tests with a local `auth-service`, including starting necessary containers and running gateway authentication tests.
* Updated the existing `quick-test` target to ensure the `AUTH_SERVICE_CONTEXT` environment variable is set and to streamline service startup for fast integration tests.
* Ensured the `AUTH_SERVICE_CONTEXT` environment variable is set when starting infrastructure for tests in both the Makefile and CI workflow, improving consistency and reliability. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L44-R44) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR89-R90)

**Code and style improvements:**

* Minor import style fix in `service_test.go` for consistency.
* Updated `.PHONY` targets in the Makefile to include the new `quick-test-local` target.…ting